### PR TITLE
libghostty-vt-sys: embed RPATH in build

### DIFF
--- a/crates/libghostty-vt-sys/build.rs
+++ b/crates/libghostty-vt-sys/build.rs
@@ -80,6 +80,10 @@ fn main() {
 
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
     println!("cargo:rustc-link-lib=dylib=ghostty-vt");
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,{}",
+        lib_dir.display()
+    );
     println!("cargo:include={}", include_dir.display());
 }
 


### PR DESCRIPTION
## Summary
- Adds `cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}` to the build script so the dynamic linker can find `libghostty-vt` at runtime without needing `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH`.

## Test plan
- [ ] Build a downstream crate that links `libghostty-vt` and verify `ldd` / `otool -L` shows the embedded rpath
- [ ] Confirm the binary runs without setting library path env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)