### PR TITLE
libghostty-vt: Use correct enum variant in rgb color style match statement

### DIFF
--- a/crates/libghostty-vt/src/style.rs
+++ b/crates/libghostty-vt/src/style.rs
@@ -201,7 +201,7 @@ impl From<StyleColor> for ffi::StyleColor {
                 value: ffi::StyleColorValue { palette },
             },
             StyleColor::Rgb(rgb) => Self {
-                tag: ffi::StyleColorTag::NONE,
+                tag: ffi::StyleColorTag::RGB,
                 value: ffi::StyleColorValue { rgb: rgb.into() },
             },
         }


### PR DESCRIPTION
Fixes a typo that set the wrong tag on the RGB color style when converting from the FFI type.