### PR TITLE
rust: set msrv to 1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/uzaaft/libghostty-rs"
-rust-version = "1.92"
+rust-version = "1.90"
 version = "0.1.1"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,16 @@
 [workspace]
-members = ["crates/libghostty-vt", "crates/libghostty-vt-sys", "example/ghostling_rs"]
+members = [
+  "crates/libghostty-vt",
+  "crates/libghostty-vt-sys",
+  "example/ghostling_rs",
+]
 resolver = "2"
 
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/uzaaft/libghostty-rs"
-rust-version = "1.93"
+rust-version = "1.92"
 version = "0.1.1"
 
 [workspace.dependencies]

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
           overlays = [(import rust-overlay)];
         };
 
-        rustVersion = "1.92.0";
+        rustVersion = "1.90.0";
         rustExtensions = ["rust-src" "rust-std" "clippy" "rustfmt" "rust-analyzer"];
 
         toolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
           overlays = [(import rust-overlay)];
         };
 
-        rustVersion = "1.93.0";
+        rustVersion = "1.92.0";
         rustExtensions = ["rust-src" "rust-std" "clippy" "rustfmt" "rust-analyzer"];
 
         toolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {


### PR DESCRIPTION
I'm unsure if it should be 1.92 or if we should bump it down even further to 1.90. Thoughts? @pluiedev 