### PR TITLE
build(vt-sys): support 64-bit Android targets in vendored zig build

### DIFF
--- a/crates/libghostty-vt-sys/build.rs
+++ b/crates/libghostty-vt-sys/build.rs
@@ -389,6 +389,8 @@ fn zig_target(target: &str) -> String {
         "aarch64-pc-windows-gnullvm" => "aarch64-windows-gnu",
         "x86_64-pc-windows-msvc" => "x86_64-windows-msvc",
         "aarch64-pc-windows-msvc" => "aarch64-windows-msvc",
+        "aarch64-linux-android" => "aarch64-linux-android",
+        "x86_64-linux-android" => "x86_64-linux-android",
         other => panic!("unsupported Rust target for vendored build: {other}"),
     };
     value.to_owned()


### PR DESCRIPTION
## What

Map the 64-bit Android Rust target triples to their zig equivalents in
`zig_target()`, so the vendored build can cross-compile `libghostty-vt` for
Android instead of panicking with
`unsupported Rust target for vendored build: aarch64-linux-android`.

```rust
"aarch64-linux-android" => "aarch64-linux-android",
"x86_64-linux-android"  => "x86_64-linux-android",
```

## Why

Ghostty's VT library already supports Android upstream — `GhosttyLibVt.zig`
handles `abi.isAndroid()` (16 KB page size for Android 15+, and wires the NDK
sysroot via `android_ndk.addPaths`). The only thing blocking the Rust wrapper
was the missing entry in this target whitelist; everything downstream already
works.

## Build requirement

Android builds need the NDK locatable at build time, the same way
`android_ndk.addPaths` documents it — set one of:

- `ANDROID_NDK_HOME` (path including the NDK version), or
- `ANDROID_HOME` / `ANDROID_SDK_ROOT` (latest installed NDK is auto-selected)

No change to non-Android targets.

## Verification

Cross-compiled both crates for the two targets on an Intel macOS (x86_64) host:

- toolchain: zig 0.15.2, NDK r25c, Rust 1.90 + `rust-std` for each target
- `cargo build -p libghostty-vt --target aarch64-linux-android` -> Finished,
  emits `libghostty-vt.a` (Android ar archive), links clean
- `cargo build -p libghostty-vt --target x86_64-linux-android`  -> Finished,
  emits `libghostty-vt.a`

```
$ cargo build -p libghostty-vt --target aarch64-linux-android
   Compiling libghostty-vt-sys v0.1.1
   Compiling libghostty-vt v0.1.1
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## Scope: 64-bit only

32-bit Android (`armv7-linux-androideabi`, `i686-linux-android`) is
intentionally left out. The checked-in `bindings.rs` encodes 64-bit struct
layouts (e.g. `["Size of String"][size_of::<String>() - 16usize]`), so 32-bit
targets fail the generated `size_of` asserts with `E0080`; `i686` additionally
isn't a valid zig arch (zig expects `x86-…`, not `i686-…`). Supporting them
needs width-specific bindings regeneration.
