### PR TITLE
vt-sys: allow overriding the zig executable via LIBGHOSTTY_VT_SYS_ZIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Building
 
-Requires [Zig](https://ziglang.org/) 0.15.x on PATH. By default, the ghostty
-source is fetched automatically at build time from the pinned commit in
-`build.rs`. Set `GHOSTTY_SOURCE_DIR` to make the build use a local Ghostty
-checkout instead. Package managers that need network-free builds can also set
+Requires [Zig](https://ziglang.org/) 0.15.x on PATH. Set `LIBGHOSTTY_VT_SYS_ZIG`
+to a specific Zig executable to use instead of `zig` from PATH, e.g. when the
+Zig on PATH is a different release than the pinned Ghostty source requires. By
+default, the ghostty source is fetched automatically at build time from the
+pinned commit in `build.rs`. Set `GHOSTTY_SOURCE_DIR` to make the build use a
+local Ghostty checkout instead. Package managers that need network-free builds can also set
 `GHOSTTY_ZIG_SYSTEM_DIR` to a pre-fetched Zig package directory; this is passed
 to `zig build --system` so Zig does not download package dependencies during
 the Cargo build script.

--- a/crates/libghostty-vt-sys/README.md
+++ b/crates/libghostty-vt-sys/README.md
@@ -7,6 +7,10 @@ Raw FFI bindings for libghostty-vt.
 - Static linking is the baseline rather than a Cargo feature. Enable the
   additive `link-dynamic` feature to link the shared library instead.
 - Set `GHOSTTY_SOURCE_DIR` to force the build to use a local Ghostty checkout.
+- Set `LIBGHOSTTY_VT_SYS_ZIG` to a specific Zig executable (a path or a command
+  name) to use instead of `zig` from PATH. This is intended for systems where
+  the Zig on PATH is a different release than the pinned Ghostty source
+  requires.
 - Set `GHOSTTY_ZIG_SYSTEM_DIR` to force Zig package resolution through a
   pre-fetched `zig build --system` directory. This is intended for Nix and other
   sandboxed package managers that cannot fetch during build scripts.

--- a/crates/libghostty-vt-sys/build.rs
+++ b/crates/libghostty-vt-sys/build.rs
@@ -72,6 +72,7 @@ fn main() {
     let link_mode = LinkMode::current();
 
     println!("cargo:rerun-if-env-changed=LIBGHOSTTY_VT_SYS_OPTIMIZE");
+    println!("cargo:rerun-if-env-changed=LIBGHOSTTY_VT_SYS_ZIG");
     println!("cargo:rerun-if-env-changed=GHOSTTY_SOURCE_DIR");
     println!("cargo:rerun-if-env-changed=GHOSTTY_ZIG_SYSTEM_DIR");
     println!("cargo:rerun-if-env-changed=TARGET");
@@ -127,7 +128,7 @@ fn build_vendored(link_mode: LinkMode) {
 
     let optimize = zig_optimize_mode();
 
-    let mut build = Command::new("zig");
+    let mut build = zig_command();
     build
         .arg("build")
         .arg("-Demit-lib-vt")
@@ -293,6 +294,22 @@ fn emit_include_metadata(include_paths: &[PathBuf]) {
 /// Defaults to `ReleaseFast` for optimized builds. If `DEBUG` is `true` (as cargo sets for the
 /// `dev` profile), `Debug` mode is used. Otherwise, if `OPT_LEVEL` is `s` or `z`, `ReleaseSmall`
 /// is used.
+/// Resolve the Zig executable used for vendored builds. Defaults to `zig` on
+/// PATH. Set `LIBGHOSTTY_VT_SYS_ZIG` to a specific executable (a path or a
+/// command name) when the Zig on PATH is not the release the pinned Ghostty
+/// source requires, e.g. a versioned Homebrew keg's
+/// `/opt/homebrew/opt/zig@0.15/bin/zig`.
+fn zig_command() -> Command {
+    if let Ok(zig) = env::var("LIBGHOSTTY_VT_SYS_ZIG") {
+        assert!(
+            !zig.is_empty(),
+            "LIBGHOSTTY_VT_SYS_ZIG must not be empty when set"
+        );
+        return Command::new(zig);
+    }
+    Command::new("zig")
+}
+
 fn zig_optimize_mode() -> &'static str {
     if let Ok(override_mode) = env::var("LIBGHOSTTY_VT_SYS_OPTIMIZE") {
         return match override_mode.as_str() {


### PR DESCRIPTION
## What

Adds a `LIBGHOSTTY_VT_SYS_ZIG` environment variable that lets vendored builds use a specific Zig executable (a path or a command name) instead of `zig` from PATH. Follows the same shape as the existing `GHOSTTY_ZIG_SYSTEM_DIR` / `LIBGHOSTTY_VT_SYS_OPTIMIZE` knobs: `rerun-if-env-changed`, non-empty assert, documented in both READMEs.

## Why

The pinned Ghostty commit requires Zig 0.15.x, but package managers often ship a newer default — e.g. Homebrew's unversioned `zig` is 0.16 and the versioned `zig@0.15` keg is keg-only, so it never lands on PATH. Today the only workarounds are mutating PATH for every `cargo` invocation or patching the crate. With this knob, downstream projects can pin the right Zig once, e.g. in `.cargo/config.toml`:

```toml
[env]
LIBGHOSTTY_VT_SYS_ZIG = "/opt/homebrew/opt/zig@0.15/bin/zig"
```

## Testing

On a machine where PATH `zig` is 0.16.0 and Homebrew `zig@0.15` (0.15.2) is keg-only:

- `cargo build -p libghostty-vt-sys` fails (Ghostty's build panics under 0.16)
- `LIBGHOSTTY_VT_SYS_ZIG=/opt/homebrew/opt/zig@0.15/bin/zig cargo build -p libghostty-vt-sys` succeeds
- `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)