### PR TITLE
libghostty-vt-sys: build iOS targets through ghostty's xcframework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
         if: matrix.flake_check
         run: nix flake check --print-build-logs
 
+      # Exercises the vendored iOS xcframework build path, which needs a
+      # macOS host with the real Xcode toolchain (the dev shell strips the
+      # Nix SDK wrappers so zig detects the system SDKs).
+      - name: Check iOS vendored build
+        if: runner.os == 'macOS'
+        run: nix develop -c cargo check --locked -p libghostty-vt-sys --target aarch64-apple-ios
+
   miri:
     name: Linux Miri
     runs-on: namespace-profile-linux-x86-sm

--- a/crates/libghostty-vt-sys/README.md
+++ b/crates/libghostty-vt-sys/README.md
@@ -15,6 +15,11 @@ Raw FFI bindings for libghostty-vt.
   another Zig CPU expression to optimize for known deployment hardware.
 - Set `LIBGHOSTTY_VT_SYS_OPTIMIZE` to `Debug`, `ReleaseSafe`, `ReleaseFast`, or
   `ReleaseSmall` to override the Zig optimize mode used by vendored builds.
+- iOS targets (`aarch64-apple-ios`, `aarch64-apple-ios-sim`) build through
+  ghostty's xcframework emit instead of a flat cross build. This requires a
+  macOS host with Xcode and the iOS SDK installed, and supports static linking
+  only. The simulator library is arm64-only (what simulators run on Apple
+  silicon), so `x86_64-apple-ios` is not supported.
 - If the `pkg-config` feature is enabled, the build will use an installed
   `libghostty-vt` found through `pkg-config` only when `GHOSTTY_SOURCE_DIR` is
   unset. With the default static link mode, it probes Ghostty's

--- a/crates/libghostty-vt-sys/build.rs
+++ b/crates/libghostty-vt-sys/build.rs
@@ -139,6 +139,15 @@ fn build_vendored(link_mode: LinkMode) {
         "LIBGHOSTTY_VT_SYS_CPU must not be empty when set"
     );
 
+    // iOS builds go through ghostty's emit-xcframework path instead of a flat
+    // `-Dtarget=<ios> --sysroot=<sdk>` invocation. The flat build breaks down
+    // for iOS: a generic target baseline can't compile simdutf's always_inline
+    // NEON intrinsics, and `--sysroot` applies globally so it leaks into the
+    // native codegen tools ghostty runs mid-build. The xcframework path runs
+    // host-native and configures each Apple platform itself, so we build that
+    // and pull out the library we need afterwards.
+    let ios_platform = ios_xcframework_platform(&target);
+
     let mut build = Command::new("zig");
     build
         .arg("build")
@@ -149,8 +158,16 @@ fn build_vendored(link_mode: LinkMode) {
         // make distributed binaries fail with an illegal instruction. Users
         // building for a known machine can explicitly request `native` or a
         // named Zig CPU model through LIBGHOSTTY_VT_SYS_CPU.
+        //
+        // For iOS builds this only affects the host-native flat artifacts:
+        // ghostty resolves its own per-platform targets for the xcframework
+        // slices, so -Dcpu does not leak into them.
         .arg(format!("-Dcpu={cpu}"))
-        .arg("-Demit-xcframework=false")
+        .arg(if ios_platform.is_some() {
+            "-Demit-xcframework=true"
+        } else {
+            "-Demit-xcframework=false"
+        })
         .arg("-Dapp-runtime=none")
         .arg("--prefix")
         .arg(&install_prefix)
@@ -179,19 +196,28 @@ fn build_vendored(link_mode: LinkMode) {
             .arg(&zig_global_cache_dir);
     }
 
-    // Only pass -Dtarget when cross-compiling. For native builds, let zig
-    // auto-detect the host (matches how ghostty's own CMakeLists.txt works).
-    if target != host {
+    // Pass -Dtarget only for non-iOS cross targets; native builds let zig
+    // auto-detect the host. iOS builds run host-native inside the xcframework
+    // emit, so they must not pass -Dtarget or a global --sysroot.
+    if target != host && ios_platform.is_none() {
         let zig_target = zig_target(&target);
         build.arg(format!("-Dtarget={zig_target}"));
     }
 
     run(build, "zig build");
 
+    // The emit also installs host-native flat artifacts; replace them with the
+    // iOS library so the link emission below picks up the right arch.
+    if let Some(platform) = ios_platform {
+        extract_xcframework_lib(&install_prefix, platform);
+    }
+
     let lib_dir = install_prefix.join("lib");
     let include_dir = install_prefix.join("include");
     let search_dirs = library_search_dirs(&target, &install_prefix);
-    warn_unused_xcframework(&lib_dir);
+    if ios_platform.is_none() {
+        warn_unused_xcframework(&lib_dir);
+    }
 
     let has_requested_library = search_dirs.iter().any(|dir| {
         std::fs::read_dir(dir)
@@ -404,6 +430,78 @@ fn library_search_dirs(target: &str, install_prefix: &Path) -> Vec<PathBuf> {
     dirs
 }
 
+/// The platform directory inside `ghostty-vt.xcframework` for an iOS Rust
+/// target, or `None` for targets that build directly via `-Dtarget`. Ghostty
+/// emits an arm64-only simulator library (what the simulator runs on Apple
+/// silicon), so x86_64-apple-ios is not supported here.
+fn ios_xcframework_platform(target: &str) -> Option<&'static str> {
+    match target {
+        "aarch64-apple-ios" => Some("ios-arm64"),
+        "aarch64-apple-ios-sim" => Some("ios-arm64-simulator"),
+        _ => None,
+    }
+}
+
+/// Copy an xcframework platform's static lib + headers into the flat
+/// `<prefix>/lib/libghostty-vt.a` and `<prefix>/include` layout the link
+/// emission expects, replacing the host-native artifacts the emit installed.
+fn extract_xcframework_lib(install_prefix: &Path, platform: &str) {
+    let platform_dir = install_prefix
+        .join("lib")
+        .join("ghostty-vt.xcframework")
+        .join(platform);
+    assert!(
+        platform_dir.is_dir(),
+        "expected xcframework platform dir {platform} at {}",
+        platform_dir.display()
+    );
+    // ghostty names the Apple static libraries `libghostty-vt-fat.a`.
+    let src_lib = platform_dir.join("libghostty-vt-fat.a");
+    assert!(
+        src_lib.exists(),
+        "expected static lib at {}",
+        src_lib.display()
+    );
+
+    let lib_dir = install_prefix.join("lib");
+    let dest_lib = lib_dir.join("libghostty-vt.a");
+    std::fs::copy(&src_lib, &dest_lib).unwrap_or_else(|error| {
+        panic!(
+            "failed to copy {} -> {}: {error}",
+            src_lib.display(),
+            dest_lib.display()
+        )
+    });
+
+    // Headers are arch-independent, but prefer the platform's own copy.
+    let headers = platform_dir.join("Headers");
+    if headers.is_dir() {
+        copy_dir_all(&headers, &install_prefix.join("include"));
+    }
+}
+
+/// Recursively copy a directory tree (merging into `dst` if it exists).
+fn copy_dir_all(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst)
+        .unwrap_or_else(|error| panic!("failed to create {}: {error}", dst.display()));
+    let entries = std::fs::read_dir(src)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", src.display()));
+    for entry in entries {
+        let entry = entry
+            .unwrap_or_else(|error| panic!("failed to read entry in {}: {error}", src.display()));
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let file_type = entry
+            .file_type()
+            .unwrap_or_else(|error| panic!("failed to stat {}: {error}", from.display()));
+        if file_type.is_dir() {
+            copy_dir_all(&from, &to);
+        } else {
+            std::fs::copy(&from, &to)
+                .unwrap_or_else(|error| panic!("failed to copy {}: {error}", from.display()));
+        }
+    }
+}
 fn zig_target(target: &str) -> String {
     let value = match target {
         "x86_64-unknown-linux-gnu" => "x86_64-linux-gnu",

--- a/crates/libghostty-vt-sys/build.rs
+++ b/crates/libghostty-vt-sys/build.rs
@@ -147,6 +147,25 @@ fn build_vendored(link_mode: LinkMode) {
     // host-native and configures each Apple platform itself, so we build that
     // and pull out the library we need afterwards.
     let ios_platform = ios_xcframework_platform(&target);
+    if ios_platform.is_some() {
+        // Ghostty only emits the xcframework when zig itself runs on macOS
+        // (it shells out to xcodebuild). Without this check a Linux cross
+        // build would silently produce a host-native library and then fail on
+        // a confusing missing-xcframework assertion after the full build.
+        assert!(
+            host.contains("apple-darwin"),
+            "building for {target} requires a macOS host with Xcode and the iOS SDK \
+             (ghostty's emit-xcframework path runs host-native); host is {host}"
+        );
+        // The xcframework contains only static archives, and the flat layout
+        // below is populated from one of them. Fail up front instead of
+        // letting the shared-library search fail with a misleading message.
+        assert!(
+            matches!(link_mode, LinkMode::Static),
+            "building for {target} supports static linking only; \
+             disable the link-dynamic feature"
+        );
+    }
 
     let mut build = Command::new("zig");
     build
@@ -450,9 +469,14 @@ fn extract_xcframework_lib(install_prefix: &Path, platform: &str) {
         .join("lib")
         .join("ghostty-vt.xcframework")
         .join(platform);
+    // Ghostty emits iOS xcframework slices only when it detects the iOS SDK,
+    // silently skipping them otherwise, so a missing directory here almost
+    // always means the SDK is absent rather than a build failure.
     assert!(
         platform_dir.is_dir(),
-        "expected xcframework platform dir {platform} at {}",
+        "expected xcframework platform dir {platform} at {}; \
+         ghostty emits iOS slices only when the iOS SDK is detected, \
+         so install it via Xcode (Settings > Components)",
         platform_dir.display()
     );
     // ghostty names the Apple static libraries `libghostty-vt-fat.a`.
@@ -502,6 +526,7 @@ fn copy_dir_all(src: &Path, dst: &Path) {
         }
     }
 }
+
 fn zig_target(target: &str) -> String {
     let value = match target {
         "x86_64-unknown-linux-gnu" => "x86_64-linux-gnu",

--- a/flake.nix
+++ b/flake.nix
@@ -40,11 +40,23 @@
         };
 
         rustVersion = "1.90.0";
-        buildToolchain = pkgs.rust-bin.stable.${rustVersion}.minimal;
-        rustTargets = pkgs.lib.optionals pkgs.stdenv.isLinux [
-          "x86_64-unknown-linux-gnu"
-          "x86_64-unknown-linux-musl"
-        ];
+        # crane's devShell puts this toolchain's cargo/rustc ahead of the
+        # devToolchain in packages, so it must carry the cross targets too or
+        # its sysroot (without their std) shadows the devToolchain's.
+        buildToolchain = pkgs.rust-bin.stable.${rustVersion}.minimal.override {
+          targets = rustTargets;
+        };
+        rustTargets =
+          pkgs.lib.optionals pkgs.stdenv.isLinux [
+            "x86_64-unknown-linux-gnu"
+            "x86_64-unknown-linux-musl"
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            # iOS builds go through the vendored zig xcframework path and
+            # need the target's std so the dev shell can cargo-check them.
+            "aarch64-apple-ios"
+            "aarch64-apple-ios-sim"
+          ];
 
         checkToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = ["clippy" "rustfmt"];


### PR DESCRIPTION
Building for `aarch64-apple-ios{,-sim}` with a flat `-Dtarget` + `--sysroot` doesn't work because: the generic CPU baseline chokes on simdutf's always_inline NEON intrinsics, and the sysroot is global to `zig build` so it bleeds into the native codegen tools ghostty runs mid-build.

Ghostty's emit-xcframework path solves both, so for iOS we just drive that and pull the static lib + headers back out into the flat layout the link step expects. Other targets are untouched.

Simulator is arm64-only (that's all ghostty emits, and it's what the simulator runs on Apple silicon). 

mac needed with xcode sdk's so current ci doesnt exercise it afiak
